### PR TITLE
docs: fix PlotETM language help

### DIFF
--- a/com/PlotETM.py
+++ b/com/PlotETM.py
@@ -580,7 +580,7 @@ def main():
 
     parser.add_argument('-lang', '--language', type=str, default='eng',
                         help="Change the language of the plots. Default is English. "
-                        "Use ESP to select Spanish. To add more languages, "
+                        "Use SPA to select Spanish. To add more languages, "
                         "include the ISO 639-1 code in etm_config")
 
     parser.add_argument('-file', '--filename', type=str, default=None,


### PR DESCRIPTION
## Summary

- update the `PlotETM.py -lang` help text to say Spanish uses `SPA`, matching the language key defined in `geode/pyETM.py`

## Validation

- `rg -n "Use (ESP|SPA) to select Spanish|language = \\{|args.language.lower" com/PlotETM.py geode/pyETM.py`
- `python3 -m py_compile com/PlotETM.py geode/pyETM.py`
- `git diff --check`
- AST check of the `-lang` argparse help string

I also tried `python3 com/PlotETM.py -h`, but this local environment does not have `matplotlib` installed, so the script exits before argparse can print help.

Fixes #250.