### PR TITLE
Fix solve_troposphere bug

### DIFF
--- a/com/LocateRinex.py
+++ b/com/LocateRinex.py
@@ -164,6 +164,9 @@ def execute_ppp(rinexinfo, args, stnm, options, sp3types, sp3altrn, brdc_path, e
                 fix_coordinate=None, solve_troposphere=105, copy_results=None, backward_substitution=False,
                 elevation_mask=5, code_only=False, save_residuals=False):
 
+    if isinstance(solve_troposphere, list):
+        solve_troposphere = solve_troposphere[0]
+
     # put the correct APR coordinates in the header.
     # stninfo = pyStationInfo.StationInfo(None, allow_empty=True)
     brdc = pyProducts.GetBrdcOrbits(brdc_path, rinexinfo.date, rinexinfo.rootdir)


### PR DESCRIPTION
The --solve_troposphere argument is defined with nargs=1, so when it is provided on the command line, argparse returns a list instead of an integer. However, the code later expects an integer value.

This causes an issue when the --solve_troposphere option is provided on the command line. The default value is not affected because it is stored as an integer. 

This change adds a check to handle the case where solve_troposphere is a list by using its first element.